### PR TITLE
Fix typo, and windows image name 

### DIFF
--- a/install-windows.sh
+++ b/install-windows.sh
@@ -533,7 +533,7 @@ cat > /root/autounattend.xml<<EOF
                 </Password>
                 <LogonCount>3</LogonCount>
                 <Username>Administrator</Username>
-                <Enabled>true</Enabled>
+                <Enabled>$AUTOLOGIN</Enabled>
             </AutoLogon>
             <UserAccounts>
                 <AdministratorPassword>

--- a/install-windows.sh
+++ b/install-windows.sh
@@ -506,7 +506,7 @@ cat > /root/autounattend.xml<<EOF
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME</Key>
-                            <Value>Windows 11 Pro</Value>
+                            <Value>Windows 10 Pro</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>
@@ -601,7 +601,7 @@ EOF
 }
 
 if [ $INSTALL_WINDOWS_VERSION == "2k22" ]; then
-  echo "Installing Windwos Server"
+  echo "Installing Windows Server"
 fi
 
 if [ $INSTALL_WINDOWS_VERSION == "w11" ]; then


### PR DESCRIPTION
The windows 11 installation was stuck at image selection.
There is a known workaround to use misleading image name with Windows **10** instead of 11.
Tested and it works.